### PR TITLE
Added `config` command

### DIFF
--- a/Commands/CommandsGroup.cs
+++ b/Commands/CommandsGroup.cs
@@ -1,5 +1,3 @@
-using DSharpPlus;
-using Zealot.Services;
 using Zealot.Services.Interfaces;
 
 namespace Zealot.Commands

--- a/Commands/ConfigCommand.cs
+++ b/Commands/ConfigCommand.cs
@@ -1,0 +1,65 @@
+using System.ComponentModel;
+using DSharpPlus.Commands;
+using DSharpPlus.Commands.ContextChecks;
+using DSharpPlus.Entities;
+
+namespace Zealot.Commands
+{
+    public partial class CommandsGroup
+    {
+        [Command("config")]
+        [Description("View or update your server’s moderation settings.")]
+        [RequirePermissions(DiscordPermission.Administrator)]
+        public async Task ConfigCommand(
+            CommandContext ctx,
+            [Description("The channel where moderator logs will be sent.")] DiscordChannel? channel = null,
+            [Description("The role that will be used for muting users.")] DiscordRole? role = null)
+        {
+            ulong guildId = ctx.Guild!.Id;
+
+            // Fetch existing settings
+            ulong? currentChannelId = await _guildSettingService.GetModerationLogChannelAsync(guildId);
+            ulong? currentRoleId = await _guildSettingService.GetMutedRoleIdAsync(guildId);
+
+            bool updated = false;
+
+            // Update settings if provided
+            if (channel is not null)
+            {
+                await _guildSettingService.SetModerationLogChannelAsync(guildId, channel.Id);
+                currentChannelId = channel.Id;
+                updated = true;
+            }
+
+            if (role is not null)
+            {
+                await _guildSettingService.SetMutedRoleIdAsync(guildId, role.Id);
+                currentRoleId = role.Id;
+                updated = true;
+            }
+
+            // Build the embed
+            var embed = new DiscordEmbedBuilder()
+                .WithTitle("Configuration Settings")
+                .WithColor(DiscordColor.Gray)
+                .WithTimestamp(DateTimeOffset.UtcNow)
+                .WithFooter($"Requested by {ctx.User.Username}", ctx.User.AvatarUrl);
+
+            embed.AddField("Mod Logs Channel",
+                currentChannelId is null ? "*Not Set*" : $"<#{currentChannelId}>",
+                inline: true);
+
+            embed.AddField("Muted Role",
+                currentRoleId is null ? "*Not Set*" : $"<@&{currentRoleId}>",
+                inline: true);
+
+            if (updated)
+                embed.WithDescription("✅ Settings have been updated.");
+
+            var response = new DiscordInteractionResponseBuilder()
+                .AddEmbed(embed);
+
+            await ctx.RespondAsync(response);
+        }
+    }
+}

--- a/Commands/LogsView.cs
+++ b/Commands/LogsView.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using DSharpPlus.Commands;
 using DSharpPlus.Entities;
-using Serilog;
 
 namespace Zealot.Commands
 {

--- a/Commands/UnBanCommand.cs
+++ b/Commands/UnBanCommand.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using DSharpPlus;
 using DSharpPlus.Commands;
 using DSharpPlus.Commands.ContextChecks;
 using DSharpPlus.Entities;

--- a/Database/models/GuildSettings.cs
+++ b/Database/models/GuildSettings.cs
@@ -8,5 +8,6 @@ namespace Zealot.Database.Models
         public ulong GuildId { get; set; }
         public string Prefix { get; set; } = "!";
         public ulong? ModerationLogChannel { get; set; }
+        public ulong? MutedRoleId { get; set; }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -13,7 +13,6 @@ using Zealot.Attributes;
 using Zealot.Commands;
 using Zealot.Services.Interfaces;
 using Zealot.Databases;
-using DSharpPlus.Commands.Processors.SlashCommands.ArgumentModifiers;
 
 namespace Zealot
 {

--- a/Services/GuildSettingService.cs
+++ b/Services/GuildSettingService.cs
@@ -3,7 +3,6 @@ using Microsoft.EntityFrameworkCore;
 using Zealot.Services.Interfaces;
 using Zealot.Database.Models;
 using Zealot.Databases;
-using System.Runtime.CompilerServices;
 
 namespace Zealot.Services
 {

--- a/Services/GuildSettingService.cs
+++ b/Services/GuildSettingService.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Zealot.Services.Interfaces;
 using Zealot.Database.Models;
 using Zealot.Databases;
+using System.Runtime.CompilerServices;
 
 namespace Zealot.Services
 {
@@ -96,5 +97,43 @@ namespace Zealot.Services
             await _dbContext.SaveChangesAsync();
         }
 
+        // Task to set the MutedRoleId in the database
+        public async Task SetMutedRoleIdAsync(ulong guildId, ulong roleId)
+        {
+            // Try to get the current settings for the guild
+            var settings = await _dbContext.GuildSettings
+                .FirstOrDefaultAsync(s => s.GuildId == guildId);
+
+            if (settings == null)
+            {
+                // Create a new record if none exists
+                settings = new GuildSettings
+                {
+                    GuildId = guildId,
+                    MutedRoleId = roleId
+                };
+
+                await _dbContext.GuildSettings.AddAsync(settings);
+            }
+            else
+            {
+                // Update the existing MutedRoleId
+                settings.MutedRoleId = roleId;
+
+                _dbContext.GuildSettings.Update(settings);
+            }
+
+            // Save the changes to the database
+            await _dbContext.SaveChangesAsync();
+        }
+
+        // Task to to get the MutedRoleId from the database
+        public async Task<ulong?> GetMutedRoleIdAsync(ulong guildId)
+        {
+            var settings = await _dbContext.GuildSettings
+                .FirstOrDefaultAsync(s => s.GuildId == guildId);
+
+            return settings?.MutedRoleId;
+        }
     }
 }

--- a/Services/Interfaces/IGuildSettingsService.cs
+++ b/Services/Interfaces/IGuildSettingsService.cs
@@ -33,5 +33,20 @@ namespace Zealot.Services.Interfaces
         /// <param name="channelId">The ID of the channel to use for moderation logs.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
         Task SetModerationLogChannelAsync(ulong guildId, ulong channelId);
+
+        /// <summary>
+        /// Sets the muted role ID for a specific guild.
+        /// </summary>
+        /// <param name="guildId">The ID of the guild.</param>
+        /// <param name="roleId">The ID of the role to be used as the muted role.</param>
+        Task SetMutedRoleIdAsync(ulong guildId, ulong roleId);
+
+        /// <summary>
+        /// Retrieves the muted role ID for a specific guild.
+        /// </summary>
+        /// <param name="guildId">The ID of the guild.</param>
+        /// <returns>The ID of the muted role, or null if not set.</returns>
+        Task<ulong?> GetMutedRoleIdAsync(ulong guildId);
+        
     }
 }


### PR DESCRIPTION
- Added a config command for administrators to view and update the moderation log channel and muted role.
- Updated database and service logic to support storing and retrieving the muted role ID.
- Closes #30.
